### PR TITLE
using new repos and released versions

### DIFF
--- a/AeroGearSyncClient.podspec
+++ b/AeroGearSyncClient.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/aerogear/aerogear-sync-server"
   s.license      = {:type => 'Apache License, Version 2.0', :file => 'LICENCE.txt'}
   s.author       = "Red Hat, Inc."
-  s.source       = {:git => 'https://github.com/danbev/aerogear-ios-sync-client.git',  :branch => 'cocoapods'}
+  s.source       = {:git => 'https://github.com/aerogear/aerogear-ios-sync-client.git',  :branch => 'cocoapods'}
   s.platform     = :ios, 8.0
   s.source_files = 'AeroGearSyncClient/*.{h,swift}'
   s.dependency  'AeroGearSync', '0.1.0'

--- a/AeroGearSyncClient.podspec
+++ b/AeroGearSyncClient.podspec
@@ -7,6 +7,7 @@ Pod::Spec.new do |s|
   s.author       = "Red Hat, Inc."
   s.source       = {:git => 'https://github.com/aerogear/aerogear-ios-sync-client.git',  :branch => 'cocoapods'}
   s.platform     = :ios, 8.0
+  s.requires_arc = 'true'
   s.source_files = 'AeroGearSyncClient/*.{h,swift}'
   s.dependency  'AeroGearSync', '0.1.0'
   s.dependency  'Starscream', '0.9.1'

--- a/Podfile
+++ b/Podfile
@@ -1,15 +1,14 @@
-source 'https://github.com/danbev/Cocoapods-repo.git'
-#source 'https://github.com/CocoaPods/Specs.git'
+source 'https://github.com/CocoaPods/Specs.git'
 
 xcodeproj 'AeroGearSyncClient.xcodeproj'
 platform :ios, '8.0'
 
-pod 'Starscream', :git => "https://github.com/daltoniam/Starscream.git", :branch => "master"
-pod 'AeroGearSync', :git => "https://github.com/danbev/aerogear-ios-sync.git", :branch => "master"
+pod 'Starscream', '0.9.1'
+pod 'AeroGearSync', :git => "https://github.com/aerogear/aerogear-ios-sync.git", :branch => "master"
 pod 'SwiftyJSON', :git => "https://github.com/SwiftyJSON/SwiftyJSON.git", :branch => "master"
 
 target 'AeroGearSyncClientTests' do
-    pod 'Starscream', :git => "https://github.com/daltoniam/Starscream.git", :branch => "master"
-    pod 'AeroGearSync', :git => "https://github.com/danbev/aerogear-ios-sync.git", :branch => "master"
+    pod 'Starscream', '0.9.1'
+    pod 'AeroGearSync', :git => "https://github.com/aerogear/aerogear-ios-sync.git", :branch => "master"
     pod 'SwiftyJSON', :git => "https://github.com/SwiftyJSON/SwiftyJSON.git", :branch => "master"
 end


### PR DESCRIPTION
@danbev @cvasilak please review (e.g. pod install)

I think for running the lint, we need to push the AeroGearSync to cocoapods (which we should/could do)