### PR TITLE
Agios 346.travis.support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: objective-c
+osx_image: xcode611
+xcode_workspace: AeroGearSyncClient.xcworkspace
+xcode_scheme: AeroGearSyncClient
+xcode_sdk: iphonesimulator
+
+before_install:
+    - gem install cocoapods --pre --no-rdoc --no-ri --no-document --quiet
+
+notifications:
+  irc: "irc.freenode.org#aerogear"
+
+branches:
+  only:
+    - master

--- a/AeroGearSyncClient.xcodeproj/project.pbxproj
+++ b/AeroGearSyncClient.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0A31614CEBC8C902A713E467 /* Pods_AeroGearSyncClientTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 06B7AF61E1884BAC4B23D3A6 /* Pods_AeroGearSyncClientTests.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		48D7D5E81A7A6B84000116C5 /* AeroGearSyncClient.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 48DBD5071A6559C1003239EC /* AeroGearSyncClient.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		48DBD5131A6559C1003239EC /* AeroGearSyncClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 48DBD5071A6559C1003239EC /* AeroGearSyncClient.framework */; };
 		48DBD55D1A655AB8003239EC /* ContentSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48DBD5571A655AB8003239EC /* ContentSerializer.swift */; };
 		48DBD55E1A655AB8003239EC /* JsonContentSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48DBD5581A655AB8003239EC /* JsonContentSerializer.swift */; };
@@ -28,6 +29,19 @@
 			remoteInfo = AeroGearSyncClient;
 		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		48D7D5E71A7A6B72000116C5 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				48D7D5E81A7A6B84000116C5 /* AeroGearSyncClient.framework in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		06B7AF61E1884BAC4B23D3A6 /* Pods_AeroGearSyncClientTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AeroGearSyncClientTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -193,6 +207,7 @@
 				48DBD5101A6559C1003239EC /* Resources */,
 				9E7731573269FBECE6C82E65 /* Embed Pods Frameworks */,
 				A88499B493E636686D49690B /* Copy Pods Resources */,
+				48D7D5E71A7A6B72000116C5 /* CopyFiles */,
 			);
 			buildRules = (
 			);

--- a/AeroGearSyncClientTests/SyncClientTests.swift
+++ b/AeroGearSyncClientTests/SyncClientTests.swift
@@ -29,7 +29,8 @@ class SyncClientTests: XCTestCase {
         self.synchonizer = JsonDiffMatchPatchSynchronizer()
         self.engine = ClientSyncEngine(synchronizer: synchonizer, dataStore: dataStore)
     }
-
+    // TODO AGIOS-344 move integration test separate target
+/*
     func testAddDocument() {
         let syncClient = SyncClient(url: "http://localhost:7777/sync", syncEngine: engine, contentSerializer: jsonContentSerializer)
         let id = NSUUID().UUIDString
@@ -61,5 +62,5 @@ class SyncClientTests: XCTestCase {
         waitForExpectationsWithTimeout(3.0, handler:nil)
         syncClient.disconnect()
     }
-
+*/
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AeroGear iOS Differential Synchronization Client 
+# AeroGear iOS Differential Synchronization Client [![Build Status](https://travis-ci.org/aerogear/aerogear-ios-sync-client.png)](https://travis-ci.org/aerogear/aerogear-ios-sync-client) 
 This project represents a client side implementation for [AeroGear Differential 
 Synchronization (DS) Server](https://github.com/danbev/aerogear-sync-server/tree/differential-synchronization).
 


### PR DESCRIPTION
@matzew in this PR:
- I've commented out integration tests, there is another ticket AGIOS-244 to move them to int test dedicated target and not to be run with travis (as they require a backend)
- I've tested locally with xctool travis build

could you review and activate travis build on that repo?