### PR TITLE
RHMAP-10094 update aerogear-ios-sync-client to Swift 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,5 @@ notifications:
 branches:
   only:
     - master
+script:
+  - xcodebuild -workspace AeroGearSyncClientJsonPatch.xcworkspace -scheme AeroGearSyncClientJsonPatch -sdk iphonesimulator build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,7 @@
 language: objective-c
-osx_image: xcode7.3
 xcode_workspace: AeroGearSyncClientJsonPatch.xcworkspace
 xcode_scheme: AeroGearSyncClientJsonPatch
 xcode_sdk: iphonesimulator
-
-before_install:
-  - pod repo update
 
 notifications:
   irc: "irc.freenode.org#aerogear"
@@ -13,5 +9,10 @@ notifications:
 branches:
   only:
     - master
+
+matrix:
+  include:
+    - osx_image: xcode7.3
+    - osx_image: xcode8
 script:
   - xcodebuild -workspace AeroGearSyncClientJsonPatch.xcworkspace -scheme AeroGearSyncClientJsonPatch -sdk iphonesimulator build

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ xcode_workspace: AeroGearSyncClientJsonPatch.xcworkspace
 xcode_scheme: AeroGearSyncClientJsonPatch
 xcode_sdk: iphonesimulator
 
+before_install:
+  - pod repo update
+
 notifications:
   irc: "irc.freenode.org#aerogear"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: objective-c
+osx_image: xcode8
 xcode_workspace: AeroGearSyncClientJsonPatch.xcworkspace
 xcode_scheme: AeroGearSyncClientJsonPatch
 xcode_sdk: iphonesimulator
+
+before_install:
+  - pod repo update
 
 notifications:
   irc: "irc.freenode.org#aerogear"
@@ -9,10 +13,5 @@ notifications:
 branches:
   only:
     - master
-
-matrix:
-  include:
-    - osx_image: xcode7.3
-    - osx_image: xcode8
 script:
   - xcodebuild -workspace AeroGearSyncClientJsonPatch.xcworkspace -scheme AeroGearSyncClientJsonPatch -sdk iphonesimulator build

--- a/AeroGearSyncClientJsonPatch.xcodeproj/project.pbxproj
+++ b/AeroGearSyncClientJsonPatch.xcodeproj/project.pbxproj
@@ -125,6 +125,7 @@
 				TargetAttributes = {
 					48D8392B1D8042FA001C4386 = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -238,7 +239,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -281,7 +282,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -308,6 +309,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -326,6 +328,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.aerogear.AeroGearSyncClientJsonPatch;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};

--- a/AeroGearSyncClientJsonPatch.xcodeproj/project.pbxproj
+++ b/AeroGearSyncClientJsonPatch.xcodeproj/project.pbxproj
@@ -120,7 +120,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 0730;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = AeroGear;
 				TargetAttributes = {
 					48D8392B1D8042FA001C4386 = {
@@ -215,8 +215,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -264,8 +266,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -285,6 +289,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -296,7 +301,9 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E2A77B4E213F989272F7C142 /* Pods-AeroGearSyncClientJsonPatch.debug.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -317,7 +324,9 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 0541381C841AD41BEA13FE0D /* Pods-AeroGearSyncClientJsonPatch.release.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;

--- a/AeroGearSyncClientJsonPatch.xcodeproj/xcshareddata/xcschemes/AeroGearSyncClientJsonPatch.xcscheme
+++ b/AeroGearSyncClientJsonPatch.xcodeproj/xcshareddata/xcschemes/AeroGearSyncClientJsonPatch.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Podfile
+++ b/Podfile
@@ -5,7 +5,17 @@ platform :ios, '8.0'
 use_frameworks!
 
 target 'AeroGearSyncClientJsonPatch' do
-	pod 'Starscream', :git => 'https://github.com/daltoniam/Starscream'
+	pod 'Starscream', :git => 'https://github.com/daltoniam/Starscream', :tag => '1.1.4'
 	pod 'AeroGearSyncJsonPatch', :git => 'https://github.com/aerogear/aerogear-ios-sync'
 end
 
+# Workaround to fix swift version to 2.3 for Pods.
+# it could be removed once CocoaPods 1.1.0 is released.
+# https://github.com/CocoaPods/CocoaPods/issues/5521
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      config.build_settings['SWIFT_VERSION'] = '2.3'
+    end
+  end
+end

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # aerogear ios sync client [![Build Status](https://travis-ci.org/aerogear/aerogear-ios-sync-client.png)](https://travis-ci.org/aerogear/aerogear-ios-sync-client) [![Pod Version](http://img.shields.io/cocoapods/v/AeroGearSyncClient.svg?style=flat)](http://cocoadocs.org/docsets/AeroGearSyncClient/)
 
-> This module currently build with Xcode 7 (Swift 2.0) and supports iOS8, iOS9.
+> This module currently build with Xcode 7.3.1 and Xcode 8 (Swift 2.3) and supports iOS8, iOS9.
 
 AeroGear iOS Differential Synchronization Client Engine represents a client side implementation for [AeroGear Differential 
 Synchronization (DS) Server](https://github.com/aerogear/aerogear-sync-server/).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # aerogear ios sync client [![Build Status](https://travis-ci.org/aerogear/aerogear-ios-sync-client.png)](https://travis-ci.org/aerogear/aerogear-ios-sync-client) [![Pod Version](http://img.shields.io/cocoapods/v/AeroGearSyncClient.svg?style=flat)](http://cocoadocs.org/docsets/AeroGearSyncClient/)
 
-> This module currently build with Xcode 7.3.1 and Xcode 8 (Swift 2.3) and supports iOS8, iOS9.
+> This module currently build with Xcode 7.3.1 and Xcode 8 (Swift 2.3) and supports iOS8, iOS9 and iOS10.
 
 AeroGear iOS Differential Synchronization Client Engine represents a client side implementation for [AeroGear Differential 
 Synchronization (DS) Server](https://github.com/aerogear/aerogear-sync-server/).


### PR DESCRIPTION
Ran the migration tool and no code changes were needed
Updated README.md
Set Deployment Target to iOS 8.0
Update Pod to use Starscream 1.1.4 as it's the Swift 2.3 version
